### PR TITLE
Fix "TypeError: must be str, not NoneType"

### DIFF
--- a/winamprpc.py
+++ b/winamprpc.py
@@ -61,17 +61,14 @@ def song_info(filepath, position):
                 audio = TinyTag.get(filepath)
         else: #Give up.
             pass
-    try:
-        artist = audio.artist
-    except:
+    artist = audio.artist
+    song = audio.title
+    album = audio.album
+    if not artist:
         artist = "Unknown Artist"
-    try:
-        song = audio.title
-    except:
+    if not song:
         song = "Unknown Song"
-    try:
-        album = audio.album
-    except:
+    if not album:
         album = "Unknown Album"
     return("👤 " + artist, "🎵 " + song, "💿 " + album)
 


### PR DESCRIPTION
Fixes error, when ID tags is not set:
```py
Traceback (most recent call last):
  File "winamprpc.py", line 92, in <module>
    songinfo = song_info(songpath, playlist_pos) #Time to get that tasty metadata.
  File "winamprpc.py", line 76, in song_info
    return("👤 " + artist, "🎵 " + song, "💿 " + album)
TypeError: must be str, not NoneType
```